### PR TITLE
Enhancements for mdl cnt cleanup reporting

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -3,6 +3,7 @@ IDNUMBER_SEARCH=*2023_4*
 MOODLE_TOKEN=xxxx
 MOODLE_USER=username
 MOODLE_PASSWORD=password
-DATA_STORE_PATH='course_data/'
+DATA_STORE_PATH="course_data/"
+LOG_STORE_PATH="course_data/"
 # On Windows:
 # DATA_STORE_PATH='G:\path\path\'

--- a/.env_example
+++ b/.env_example
@@ -3,3 +3,6 @@ IDNUMBER_SEARCH=*2023_4*
 MOODLE_TOKEN=xxxx
 MOODLE_USER=username
 MOODLE_PASSWORD=password
+DATA_STORE_PATH='course_data/'
+# On Windows:
+# DATA_STORE_PATH='G:\path\path\'

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ course_data/
 !course_data/.gitkeep
 * copy*py
 .DS_Store
+.notes.txt

--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ A helper utility can extract all urls from the activity content.
 1. Set up contributing possibility
 1. Add LTI & other content via Selenium?
 1. Add lecture capture
+1. Maybe consider
+- Provide script command options to exclude content if unused &/or hidden (or if unused to help reduce file/data size of the Moodle instance)
+- Include the Moodle contextid of the content to be able to work out which users have permissions to view, etc..  Note debug/course_modules.csv does include the contextid
 
 ## Contributing ##
 

--- a/learning_tools_content_api.code-workspace
+++ b/learning_tools_content_api.code-workspace
@@ -1,0 +1,8 @@
+{
+	"folders": [
+		{
+			"path": "."
+		}
+	],
+	"settings": {}
+}

--- a/lib/event_logger.py
+++ b/lib/event_logger.py
@@ -13,21 +13,36 @@ class EventLogger:
             output_dir (str): Directory path where log_events.csv will be stored
         """
         # self.output_dir = 'course_data/'
-        self.output_dir = os.getenv('DATA_STORE_PATH') # Note currently output_dir is the same as data_store_path
+        self.output_dir = os.getenv('LOG_STORE_PATH') # Note currently output_dir is the same as data_store_path
         self.log_file = os.path.join(self.output_dir, "log_events.csv")
         self.events = deque(maxlen=100)  # Only keep last 100 events in memory
         
         # Create output directory if it doesn't exist
         os.makedirs(self.output_dir, exist_ok=True)
         
-        # Clear existing log file if it exists
-        open(self.log_file, 'w').close()
+        # Append to the log file if it exists, otherwise create a new one
+        # and write the header but not clear the existing file.
+        #
+        # This is to prevent overwriting the file if it already exists.
+        # If the script is running as a cron job, it may be run multiple times
+        # and we don't want to lose the previous logs.
+
+        # Write CSV header only if the file does not exist
+        if not os.path.exists(self.log_file):
+            with open(self.log_file, 'a', newline='') as f:
+                writer = csv.writer(f)
+                writer.writerow(['timestamp', 'event_title', 'event_details'])
+
+        # Previous code:
+        # # Clear existing log file if it exists
+        # open(self.log_file, 'w').close()
         
-        # Write CSV header
-        with open(self.log_file, 'w', newline='') as f:
-            writer = csv.writer(f)
-            writer.writerow(['timestamp', 'event_title', 'event_details'])
-        
+        # # Write CSV header
+        # with open(self.log_file, 'w', newline='') as f:
+        #     writer = csv.writer(f)
+        #     writer.writerow(['timestamp', 'event_title', 'event_details'])
+
+
         # Register the flush_events method to run at program termination
         atexit.register(self.flush_events)
     

--- a/lib/event_logger.py
+++ b/lib/event_logger.py
@@ -12,7 +12,8 @@ class EventLogger:
         Args:
             output_dir (str): Directory path where log_events.csv will be stored
         """
-        self.output_dir = 'course_data/'
+        # self.output_dir = 'course_data/'
+        self.output_dir = os.getenv('DATA_STORE_PATH') # Note currently output_dir is the same as data_store_path
         self.log_file = os.path.join(self.output_dir, "log_events.csv")
         self.events = deque(maxlen=100)  # Only keep last 100 events in memory
         

--- a/lib/moodle_content_helpers.py
+++ b/lib/moodle_content_helpers.py
@@ -111,7 +111,9 @@ class moodle_content_helpers:
         course_label_content = self.label_content.get_label_content(course_modules, course)
         course_file_content, course_folder_content = self.file_content.get_resource_content(course_modules, course)
         course_url_content = self.url_content.get_url_content(course_modules, course)
-        course_forum_content = self.forum_content.get_forum_content(course_modules, course)
+        # I don't need forum content for now and it is generating an error so I am not calling the functions for now
+        # course_forum_content = self.forum_content.get_forum_content(course_modules, course)
+        course_forum_content = None
         return course_block_content, course_book_content, course_page_content, course_label_content, course_sections, course_file_content, course_folder_content, course_resources, course_url_content, course_forum_content
 
         # Lots more todo here

--- a/lib/moodle_content_helpers.py
+++ b/lib/moodle_content_helpers.py
@@ -17,7 +17,8 @@ from mod.forum import mod_forum
 
 class moodle_content_helpers:
     def __init__(self, moodle_rest) -> None:
-        self.data_store_path = 'course_data/'
+        # self.data_store_path = 'course_data/'
+        self.data_store_path = os.getenv('DATA_STORE_PATH')
         self.moodle_rest = moodle_rest
         self.content_cleaner = content_cleaners()
         self.block_content = block_content()

--- a/mod/moodle_mod_helper.py
+++ b/mod/moodle_mod_helper.py
@@ -197,7 +197,7 @@ class ModuleHelper:
             f'{self.component_name}_files': [],
             f'{self.component_name}_title': content.get('content', ''),
             f'{self.component_name}_filepath': content.get('filepath'),
-            f'{self.component_name}_filesize': content.get('filesize'),          
+            f'{self.component_name}_filesize': content.get('filesize'),
             f'{self.component_name}_fileurl': item_url,
             f'{self.component_name}_time_modified': content.get('timemodified'),
             f'{self.component_name}_sortorder': content.get('sortorder', 0),
@@ -207,13 +207,14 @@ class ModuleHelper:
             
             item[f'{self.component_name}_url'] = f"{module_data.get('book_url')}&chapter={item.get('chapter_id')}"
 
-            # Moodle url to text editor where the file manager can be opened and references to unused files deleted.
-            # Mock up url above to test if col & val added to CSV https://learn.rvc.ac.uk/mod/book/edit.php?cmid=58392&id=100115
+            # Adding Moodle url to text editor where - the file manager can be opened and references to unused files deleted.
+            #
+            # Mdl txt editor URL example https://example.com/mod/book/edit.php?cmid=58392&id=100115
             item[f'{self.component_name}_editor_url'] = f"https://learn.rvc.ac.uk/mod/book/edit.php?cmid={int(module_data.get(f'{self.modtype}_cmid'))}&id={item.get('chapter_id')}"
-            # print(item[f'{self.component_name}_editor_url'])
+
 
             # Human readable filesize - consider refactoring to use (currently unused) fn below called _convert_size
-            # print("item['chapter_filesize'] = ", item['chapter_filesize'], "type = ", type(item['chapter_filesize']))
+            # 
             size_bytes = int(item['chapter_filesize'])
 
             if size_bytes == 0: 
@@ -228,6 +229,7 @@ class ModuleHelper:
             item[f'{self.component_name}_filesize_readable'] = f"{human_size}"
 
             # Human readable time modified
+            #
             ts = int(item['chapter_time_modified'])
             x = datetime.fromtimestamp(ts, tz=timezone.utc)
             item[f'{self.component_name}_time_modified_readable'] = x.strftime('%Y-%m-%d %H:%M')


### PR DESCRIPTION
Hi Brian,
The changes I've made have helped provide Programme managers & others with reports on the LAN that help identify large unused files in Books.  Providing the link to the chapter edit page in Moodle where the files manager can be opened to delete the unused file reference and with the largest files sorted to the top of the report.  Alos  a .env variable to save the report in a separate folder to the log...  I've added methods to save filesize as MB and the date in a human readable format.  Can you merge this or cleanup and cherry pick the key features I've mentioned above?  I don't think they will affect the general use/aim of this api?
Kind regards
Jago